### PR TITLE
add the snap

### DIFF
--- a/snap/daemon_arguments
+++ b/snap/daemon_arguments
@@ -1,0 +1,2 @@
+# Set the command-line arguments to pass to the proxy.
+ARGS=""

--- a/snap/snap_config_wrapper
+++ b/snap/snap_config_wrapper
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+test -e $SNAP_DATA/daemon_arguments || cp $SNAP/etc/juju-introspection-proxy/daemon_arguments.example $SNAP_DATA/daemon_arguments
+
+. $SNAP_DATA/daemon_arguments
+exec $SNAP/bin/juju-introspection-proxy $ARGS

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,29 @@
+name: juju-introspection-proxy
+version: 1
+summary: A proxy to Juju internal metrics
+description: |
+  Allows scraping of Juju internal metrics by Prometheus
+confinement: classic
+grade: stable
+apps:
+  juju-introspection-proxy:
+    command: 'bin/juju-introspection-proxy.wrapper'
+    plugs: [network-bind, network]
+    daemon: simple
+parts:
+  juju-introspection-proxy:
+    plugin: go
+    source: https://github.com/axw/juju-introspection-proxy.git
+    go-importpath: github.com/axw/juju-introspection-proxy
+  snap-wrappers:
+    plugin: dump
+    source: .
+    organize:
+      snap_config_wrapper: bin/juju-introspection-proxy.wrapper
+      daemon_arguments: etc/juju-introspection-proxy/daemon_arguments.example
+    stage:
+      - bin/juju-introspection-proxy.wrapper
+      - etc/juju-introspection-proxy/daemon_arguments.example
+    prime:
+      - bin/juju-introspection-proxy.wrapper
+      - etc/juju-introspection-proxy/daemon_arguments.example


### PR DESCRIPTION
snap is classic because it must read the agents files.

Build with "snapcraft cleanbuild" if you're running 16.10 or later.